### PR TITLE
fix: 503 when private gpt gets ollama service (#2104)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,8 @@ services:
       - ollama-cuda
       - ollama-api
     depends_on:
-      - ollama
+      ollama:
+        condition: service_healthy
 
   # Private-GPT service for the local mode
   # This service builds from a local Dockerfile and runs the application in local mode.
@@ -60,6 +61,12 @@ services:
   # This will route requests to the Ollama service based on the profile.
   ollama:
     image: traefik:v2.10
+    healthcheck:
+      test: ["CMD", "sh", "-c", "wget -q --spider http://ollama:11434 || exit 1"]
+      interval: 10s
+      retries: 3
+      start_period: 5s
+      timeout: 5s
     ports:
       - "8080:8080"
     command:


### PR DESCRIPTION
When running private gpt with external ollama API, ollama service returns 503 on startup because ollama service (traefik) might not be ready.

- Add healthcheck to ollama service to test for connection to external ollama
- private-gpt-ollama service depends on ollama being service_healthy

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] I stared at the code and made sure it makes sense

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I ran `make check; make test` to ensure mypy and tests pass
